### PR TITLE
Modifications for CMS inApp documentation

### DIFF
--- a/_includes/topnav.html
+++ b/_includes/topnav.html
@@ -1,5 +1,5 @@
 <!-- Navigation -->
-<nav class="navbar navbar-inverse navbar-fixed-top">
+<nav class="navbar navbar-inverse navbar-fixed-top hidden">
     <div class="container topnavlinks">
         <div class="navbar-header">
             <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -41,10 +41,11 @@
 
     <script>
         $(document).ready ( function(){
-            if(document.location.href.indexOf('fromCms=true') !== -1){
-            $('nav').addClass('hidden');
-            $('.col-md-3').addClass('hidden');
-            }
+          if(document.location.href.indexOf('fromCms=true') === -1){
+            $('body').css('padding-top', '50px');
+            $('nav').removeClass('hidden');
+            $('.col-md-3').removeClass('hidden');
+          }
         });
     </script>
 
@@ -67,11 +68,10 @@
 {% include topnav.html %}
 <!-- Page Content -->
 <div class="container">
-    <div class="col-lg-12">&nbsp;</div>
     <!-- Content Row -->
     <div class="row">
         <!-- Sidebar Column -->
-        <div class="col-md-3">
+        <div class="col-md-3 hidden">
 
           {% include sidebar.html %}
     <!-- Content Column -->

--- a/css/customstyles.css
+++ b/css/customstyles.css
@@ -1,5 +1,6 @@
 body {
     font-size:15px;
+    padding-top: 0; /* Padding is added dynamically if there is a .navbar-fixed-top. */
 }
 
 .bs-callout {


### PR DESCRIPTION
Remove padding top and modify top and side bars to be hidden by default and inserted when there isn't an url parameter.

This is usefull because without it, bars are shown for a second in the inApp documentation and a big padding top is setted.