### PR TITLE
[documentation]: fixed several broken links

### DIFF
--- a/_data/topnav.yml
+++ b/_data/topnav.yml
@@ -4,7 +4,7 @@ topnav:
 - title: Topnav
   items:
     - title: News
-      url: /news.html
+      url: /tag_news.html
 
 #Topnav dropdowns
 topnav_dropdowns:

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -33,4 +33,4 @@
 <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
 <![endif]-->
 
-<link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "feed.xml" | prepend: site.url }}">
+<link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.url }}">


### PR DESCRIPTION
I have fixed two broken links in the documentation:
- wrong filename in News link (header)
- missing slash in RSS feeds (meta)

