### PR TITLE
[documentation]: hide javascript sdk from top nav bar

### DIFF
--- a/_data/topnav.yml
+++ b/_data/topnav.yml
@@ -20,7 +20,5 @@ topnav_dropdowns:
           url: /android_home.html
         - title: HALO iOS SDK Documentation
           url: /ios_home.html
-        - title: HALO Javascript SDK Documentation
-          url: /javascript_home.html
         - title: HALO Server Integrations
           url: /server_integrations_home.html


### PR DESCRIPTION
hide top nav bar javasacript sdl